### PR TITLE
Added beep support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,3 +11,4 @@ Imports: crayon,
     glue,
     purrr,
     rstudioapi
+Suggests: beepr

--- a/R/aside.R
+++ b/R/aside.R
@@ -8,13 +8,14 @@
 #' @importFrom purrr map
 #'
 #' @param cmd the cmd to send
-#' @param show wether or not to show the terminal
+#' @param show whether or not to show the terminal
+#' @param beep whether or not to play a sound when the job is done, using the beepr package when available.
 #'
 #' @return a job well done
 #' @export
 #'
 
-aside <- function(cmd, show = FALSE){
+aside <- function(cmd, show = FALSE, beep = FALSE) {
   # Check system info
   os <- Sys.info()[["sysname"]]
 
@@ -50,6 +51,9 @@ aside <- function(cmd, show = FALSE){
 
   terminalSend(a, paste0('save(list = ls(all.names = TRUE, envir = .GlobalEnv),file = "',file,'",envir = .GlobalEnv) \n'))
 
+  if (beep) {
+    terminalSend(a, 'if (requireNamespace("beepr", quietly = TRUE)) beepr::beep() else alarm()\n')
+  }
   if (os == "Linux"){
     terminalSend(a, 'try(system(\'notify-send "Aside job completed"\'))\n')
   } else if (os == "Darwin"){

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ You can also watch over the process by opening the terminal with:
 aside("a <- 12", show = TRUE)
 ```
 
+If you're a fan of annoying notification sounds, you can also use (best with [beepr](https://cran.r-project.org/web/packages/beepr/index.html) installed)
+``` r
+aside("a <- 12", beep = TRUE)
+```
+
 Windows users
 -------------
 

--- a/man/aside.Rd
+++ b/man/aside.Rd
@@ -4,12 +4,14 @@
 \alias{aside}
 \title{Aside}
 \usage{
-aside(cmd, show = FALSE)
+aside(cmd, show = FALSE, beep = FALSE)
 }
 \arguments{
 \item{cmd}{the cmd to send}
 
-\item{show}{wether or not to show the terminal}
+\item{show}{whether or not to show the terminal}
+
+\item{beep}{whether or not to play a sound when the job is done, using the beepr package when available.}
 }
 \value{
 a job well done


### PR DESCRIPTION
It suggests the beepr package and uses it if available, otherwise uses `alert()` as fallback (which mostly does nothing on many systems, apparently).